### PR TITLE
Bumping to Angular v11 & removing duplicate interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ aot/
 aot2/
 angular2-webpack-starter/
 testionic/
+
+# VS code
+.vscode

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "wp-api-angular",
-  "version": "3.0.0-beta8",
-  "description": "WordPress WP-API v2 client for Angular2",
+  "name": "wp-api-angular2",
+  "version": "4.0.0",
+  "description": "WordPress WP-API v2 client for Angular2+",
   "main": "wp-api-angular.js",
   "typings": "wp-api-angular.d.ts",
   "scripts": {
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/shprink/wp-api-angular"
+    "url": "https://github.com/s4m0r4m4/wp-api-angular"
   },
   "keywords": [
     "wp-api",
@@ -24,39 +24,37 @@
     "angularjs",
     "rest",
     "restfull",
-    "client"
+    "client",
+    "wordpress",
+    "json"
   ],
-  "author": "shprink <contact@julienrenaux.fr>",
+  "author": "s4m0r4m4",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/shprink/wp-api-angular/issues"
+    "url": "https://github.com/s4m0r4m4/wp-api-angular/issues"
   },
-  "homepage": "https://github.com/shprink/wp-api-angular",
-  "peerDependencies": {
-    "@angular/core": "^4.0.0",
-    "@angular/http": "^4.0.0"
-  },
+  "homepage": "https://github.com/s4m0r4m4/wp-api-angular",
   "dependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/compiler": "^4.0.0",
-    "@angular/platform-browser": "^4.0.0",
-    "@angular/platform-browser-dynamic": "^4.0.0",
-    "rxjs": "^5.0.0"
+    "@angular/common": "^11.0.0",
+    "@angular/compiler": "^11.0.0",
+    "@angular/core": "^11.0.0",
+    "@angular/platform-browser": "^11.0.0",
+    "@angular/platform-browser-dynamic": "^11.0.0",
+    "rxjs": "~6.5.5"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "^4.0.0",
+    "@angular/compiler-cli": "^11.0.0",
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
-    "core-js": "^2.4.0",
     "html-webpack-plugin": "~2.22.0",
     "json-loader": "^0.5.2",
     "path": "^0.4.9",
     "reflect-metadata": "^0.1.3",
     "ts-loader": "0.8.1",
-    "typescript": "^2.1.5",
+    "typescript": "~4.0.3",
     "util": "^0.10.3",
     "webpack": "~1.13.1",
     "webpack-dev-server": "~1.14.1",
-    "zone.js": "^0.6.12"
+    "zone.js": "^0.10.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wp-api-angular2",
+  "name": "wp-api-angular",
   "version": "4.0.0",
   "description": "WordPress WP-API v2 client for Angular2+",
   "main": "wp-api-angular.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/s4m0r4m4/wp-api-angular"
+    "url": "https://github.com/shprink/wp-api-angular"
   },
   "keywords": [
     "wp-api",
@@ -28,12 +28,12 @@
     "wordpress",
     "json"
   ],
-  "author": "s4m0r4m4",
+  "author": "shprink <contact@julienrenaux.fr>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/s4m0r4m4/wp-api-angular/issues"
+    "url": "https://github.com/shprink/wp-api-angular/issues"
   },
-  "homepage": "https://github.com/s4m0r4m4/wp-api-angular",
+  "homepage": "https://github.com/shprink/wp-api-angular",
   "dependencies": {
     "@angular/common": "^11.0.0",
     "@angular/compiler": "^11.0.0",

--- a/src/Comments.ts
+++ b/src/Comments.ts
@@ -1,28 +1,19 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiComments } from './interfaces';
+import { WpApiLoader } from './Loaders';
 import { WpApiParent } from './Parent';
 
-import { WpApiLoader } from './Loaders';
 
-export interface IWpApiComments {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(commentId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(commentId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(commentId: number, options?: RequestOptionsArgs): Observable<Response>;
-}
-
+/******************************************************************************
+* Service: WpApiComments
+******************************************************************************/
 @Injectable()
 export class WpApiComments extends WpApiParent implements IWpApiComments {
+
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/Custom.ts
+++ b/src/Custom.ts
@@ -42,7 +42,7 @@ export class WpApiCustom extends WpApiParent {
     super(wpApiLoader, http);
   }
 
-  getInstance(entityName = '') {
+  getInstance(entityName: string = '') {
     if (typeof entityName !== 'string') {
       throw new Error(`getInstance needs an entity name`);
     }

--- a/src/Custom.ts
+++ b/src/Custom.ts
@@ -1,28 +1,14 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiCustom } from './interfaces';
+import { WpApiLoader } from './Loaders';
 import { WpApiParent } from './Parent';
 
-import { WpApiLoader } from './Loaders';
-
-export interface IWpApiCustom {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(customId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(customId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(customId: number, options?: RequestOptionsArgs): Observable<Response>;
-}
 
 export class Custom extends WpApiParent implements IWpApiCustom {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http,
+    public http: HttpClient,
     public entityName: string
   ) {
     super(wpApiLoader, http);
@@ -44,12 +30,14 @@ export class Custom extends WpApiParent implements IWpApiCustom {
   }
 }
 
-
+/******************************************************************************
+* Service: WpApiCustom
+******************************************************************************/
 @Injectable()
 export class WpApiCustom extends WpApiParent {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/Loaders.ts
+++ b/src/Loaders.ts
@@ -1,14 +1,20 @@
-import { Http, HttpModule } from '@angular/http';
+
+import { HttpClient } from '@angular/common/http';
 import { stripTrailingSlash } from './utils';
 
 export abstract class WpApiLoader {
   abstract getWebServiceUrl(postfix: string): string;
 }
 
+/******************************************************************************
+* Class: WpApiStaticLoader
+******************************************************************************/
 export class WpApiStaticLoader implements WpApiLoader {
+
   completeUrl: string;
+
   constructor(
-    private http: Http,
+    private http: HttpClient,
     private baseUrl: string = 'http://changeYourDomainHere.com/wp-json',
     private namespace: string = '/wp/v2'
   ) {
@@ -18,4 +24,5 @@ export class WpApiStaticLoader implements WpApiLoader {
   public getWebServiceUrl(postfix: string): string {
     return `${this.completeUrl}${postfix}`
   }
+
 }

--- a/src/Media.ts
+++ b/src/Media.ts
@@ -1,29 +1,14 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
-import { WpApiParent } from './Parent';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiMedia } from './interfaces';
 import { WpApiLoader } from './Loaders';
-
-export interface IWpApiMedia {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(mediaId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(mediaId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(mediaId: number, options?: RequestOptionsArgs): Observable<Response>;
-}
+import { WpApiParent } from './Parent';
 
 @Injectable()
 export class WpApiMedia extends WpApiParent implements IWpApiMedia {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/Pages.ts
+++ b/src/Pages.ts
@@ -1,33 +1,15 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiPages } from './interfaces';
+import { WpApiLoader } from './Loaders';
 import { WpApiParent } from './Parent';
 
-import { WpApiLoader } from './Loaders';
-
-export interface IWpApiPages {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(pageId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(pageId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(pageId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getMetaList(pageId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getMeta(pageId: number, metaId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getRevisionList(pageId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getRevision(pageId: number, revisionId: number, options?: RequestOptionsArgs): Observable<Response>;
-}
 
 @Injectable()
 export class WpApiPages extends WpApiParent implements IWpApiPages {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/Parent.ts
+++ b/src/Parent.ts
@@ -1,30 +1,18 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IParent } from './interfaces';
 import { WpApiLoader } from './Loaders';
-import { stripTrailingSlash } from './utils';
 
 
-export interface IParent {
-  httpGet(url: string, options?: RequestOptionsArgs): Observable<Response>;
-  httpHead(url: string, options?: RequestOptionsArgs): Observable<Response>;
-  httpDelete(url: string, options?: RequestOptionsArgs): Observable<Response>;
-  httpPost(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  httpPut(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  httpPatch(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
-}
-
+/******************************************************************************
+* Service: WpApiParent
+******************************************************************************/
 @Injectable()
 export class WpApiParent implements IParent {
+
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) { }
 
   httpGet(url: string, options = {}) {

--- a/src/Posts.ts
+++ b/src/Posts.ts
@@ -1,37 +1,15 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiPosts } from './interfaces';
+import { WpApiLoader } from './Loaders';
 import { WpApiParent } from './Parent';
 
-import { WpApiLoader } from './Loaders';
-
-export interface IWpApiPosts {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(postId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getMetaList(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getMeta(postId: number, metaId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getRevisionList(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getRevision(postId: number, revisionId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getCategoryList(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getCategory(postId: number, categoryId, options?: RequestOptionsArgs): Observable<Response>;
-  getTagList(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getTag(postId: number, tagId, options?: RequestOptionsArgs): Observable<Response>;
-}
 
 @Injectable()
 export class WpApiPosts extends WpApiParent implements IWpApiPosts {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/RequestOptionsArgs.ts
+++ b/src/RequestOptionsArgs.ts
@@ -1,0 +1,11 @@
+
+type RequestMethod = "get" | "post" | "put" | "delete";
+
+export class RequestOptionsArgs {
+  url : string
+  method : string|RequestMethod
+  search : string|URLSearchParams
+  headers : Headers
+  body : any
+  withCredentials : boolean
+}

--- a/src/Statuses.ts
+++ b/src/Statuses.ts
@@ -1,26 +1,14 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
-import { WpApiParent } from './Parent';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiStatuses } from './interfaces';
 import { WpApiLoader } from './Loaders';
-
-export interface IWpApiStatuses {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(statusesName: string, options?: RequestOptionsArgs): Observable<Response>;
-}
+import { WpApiParent } from './Parent';
 
 @Injectable()
 export class WpApiStatuses extends WpApiParent implements IWpApiStatuses {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/Taxonomies.ts
+++ b/src/Taxonomies.ts
@@ -1,26 +1,17 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiTaxonomies } from './interfaces';
+import { WpApiLoader } from './Loaders';
 import { WpApiParent } from './Parent';
 
-import { WpApiLoader } from './Loaders';
 
-export interface IWpApiTaxonomies {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(taxonomiesType: string, options?: RequestOptionsArgs): Observable<Response>;
-}
+
 
 @Injectable()
 export class WpApiTaxonomies extends WpApiParent implements IWpApiTaxonomies {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/Terms.ts
+++ b/src/Terms.ts
@@ -1,23 +1,9 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiTerms } from './interfaces';
+import { WpApiLoader } from './Loaders';
 import { WpApiParent } from './Parent';
 
-import { WpApiLoader } from './Loaders';
-
-export interface IWpApiTerms {
-  getList(taxonomiesType: string, options?: RequestOptionsArgs): Observable<Response>;
-  get(taxonomiesType: string, termId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(taxonomiesType: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(taxonomiesType: string, termId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(taxonomiesType: string, termId: number, options?: RequestOptionsArgs): Observable<Response>;
-}
 
 const defaultTaxoType = 'categories';
 
@@ -25,7 +11,7 @@ const defaultTaxoType = 'categories';
 export class WpApiTerms extends WpApiParent implements IWpApiTerms {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,26 +1,16 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiTypes } from './interfaces';
+import { WpApiLoader } from './Loaders';
 import { WpApiParent } from './Parent';
 
-import { WpApiLoader } from './Loaders';
 
-export interface IWpApiTypes {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(postType: string, options?: RequestOptionsArgs): Observable<Response>;
-}
 
 @Injectable()
 export class WpApiTypes extends WpApiParent implements IWpApiTypes {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/Users.ts
+++ b/src/Users.ts
@@ -1,30 +1,14 @@
-import { Injectable, Inject } from '@angular/core';
-import { Http } from '@angular/http';
-
-// Need to import interfaces dependencies
-// Bug TypeScript https://github.com/Microsoft/TypeScript/issues/5938
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
-import { WpApiParent } from './Parent';
-
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IWpApiUsers } from './interfaces';
 import { WpApiLoader } from './Loaders';
-
-export interface IWpApiUsers {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  me(options?: RequestOptionsArgs): Observable<Response>;
-  get(userId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(userId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(userId: number, options?: RequestOptionsArgs): Observable<Response>;
-}
+import { WpApiParent } from './Parent';
 
 @Injectable()
 export class WpApiUsers extends WpApiParent implements IWpApiUsers {
   constructor(
     public wpApiLoader: WpApiLoader,
-    public http: Http
+    public http: HttpClient
   ) {
     super(wpApiLoader, http);
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,97 +1,95 @@
-import { Observable } from 'rxjs/Observable';
-import { RequestOptionsArgs } from '@angular/http/src/interfaces';
-import { Response } from '@angular/http/src/static_response';
-
+import { Observable } from "rxjs";
+import { RequestOptionsArgs } from './RequestOptionsArgs';
 
 export interface IParent {
-  httpGet(url: string, options?: RequestOptionsArgs): Observable<Response>;
-  httpHead(url: string, options?: RequestOptionsArgs): Observable<Response>;
-  httpDelete(url: string, options?: RequestOptionsArgs): Observable<Response>;
-  httpPost(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  httpPut(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  httpPatch(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
+  httpGet(url: string, options?: RequestOptionsArgs): Observable<Object>;
+  httpHead(url: string, options?: RequestOptionsArgs): Observable<Object>;
+  httpDelete(url: string, options?: RequestOptionsArgs): Observable<Object>;
+  httpPost(url: string, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  httpPut(url: string, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  httpPatch(url: string, body: any, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiPosts {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(postId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getMetaList(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getMeta(postId: number, metaId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getRevisionList(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getRevision(postId: number, revisionId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getCategoryList(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getCategory(postId: number, categoryId, options?: RequestOptionsArgs): Observable<Response>;
-  getTagList(postId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getTag(postId: number, tagId, options?: RequestOptionsArgs): Observable<Response>;
+  getList(options?: RequestOptionsArgs): Observable<Object>;
+  get(postId: number, options?: RequestOptionsArgs): Observable<Object>;
+  create(body: any, options?: RequestOptionsArgs): Observable<Object>;
+  update(postId: number, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  delete(postId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getMetaList(postId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getMeta(postId: number, metaId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getRevisionList(postId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getRevision(postId: number, revisionId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getCategoryList(postId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getCategory(postId: number, categoryId, options?: RequestOptionsArgs): Observable<Object>;
+  getTagList(postId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getTag(postId: number, tagId, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiPages {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(pageId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(pageId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(pageId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getMetaList(pageId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getMeta(pageId: number, metaId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getRevisionList(pageId: number, options?: RequestOptionsArgs): Observable<Response>;
-  getRevision(pageId: number, revisionId: number, options?: RequestOptionsArgs): Observable<Response>;
+  getList(options?: RequestOptionsArgs): Observable<Object>;
+  get(pageId: number, options?: RequestOptionsArgs): Observable<Object>;
+  create(body: any, options?: RequestOptionsArgs): Observable<Object>;
+  update(pageId: number, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  delete(pageId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getMetaList(pageId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getMeta(pageId: number, metaId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getRevisionList(pageId: number, options?: RequestOptionsArgs): Observable<Object>;
+  getRevision(pageId: number, revisionId: number, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiComments {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(commentId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(commentId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(commentId: number, options?: RequestOptionsArgs): Observable<Response>;
+  getList(options?: RequestOptionsArgs): Observable<Object>;
+  get(commentId: number, options?: RequestOptionsArgs): Observable<Object>;
+  create(body: any, options?: RequestOptionsArgs): Observable<Object>;
+  update(commentId: number, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  delete(commentId: number, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiTypes {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(postType: string, options?: RequestOptionsArgs): Observable<Response>;
+  getList(options?: RequestOptionsArgs): Observable<Object>;
+  get(postType: string, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiMedia {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(mediaId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(mediaId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(mediaId: number, options?: RequestOptionsArgs): Observable<Response>;
+  getList(options?: RequestOptionsArgs): Observable<Object>;
+  get(mediaId: number, options?: RequestOptionsArgs): Observable<Object>;
+  create(body: any, options?: RequestOptionsArgs): Observable<Object>;
+  update(mediaId: number, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  delete(mediaId: number, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiUsers {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  me(options?: RequestOptionsArgs): Observable<Response>;
-  get(userId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(userId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(userId: number, options?: RequestOptionsArgs): Observable<Response>;
+  getList(options?: RequestOptionsArgs): Observable<Object>;
+  me(options?: RequestOptionsArgs): Observable<Object>;
+  get(userId: number, options?: RequestOptionsArgs): Observable<Object>;
+  create(body: any, options?: RequestOptionsArgs): Observable<Object>;
+  update(userId: number, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  delete(userId: number, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiTaxonomies {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(taxonomiesType: string, options?: RequestOptionsArgs): Observable<Response>;
+  getList(options?: RequestOptionsArgs): Observable<Object>;
+  get(taxonomiesType: string, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiStatuses {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(statusesName: string, options?: RequestOptionsArgs): Observable<Response>;
+  getList(options?: RequestOptionsArgs): Observable<Object>;
+  get(statusesName: string, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiTerms {
-  getList(taxonomiesType: string, options?: RequestOptionsArgs): Observable<Response>;
-  get(taxonomiesType: string, termId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(taxonomiesType: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(taxonomiesType: string, termId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(taxonomiesType: string, termId: number, options?: RequestOptionsArgs): Observable<Response>;
+  getList(taxonomiesType: string, options?: RequestOptionsArgs): Observable<Object>;
+  get(taxonomiesType: string, termId: number, options?: RequestOptionsArgs): Observable<Object>;
+  create(taxonomiesType: string, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  update(taxonomiesType: string, termId: number, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  delete(taxonomiesType: string, termId: number, options?: RequestOptionsArgs): Observable<Object>;
 }
 
 export interface IWpApiCustom {
-  getList(options?: RequestOptionsArgs): Observable<Response>;
-  get(customId: number, options?: RequestOptionsArgs): Observable<Response>;
-  create(body: any, options?: RequestOptionsArgs): Observable<Response>;
-  update(customId: number, body: any, options?: RequestOptionsArgs): Observable<Response>;
-  delete(customId: number, options?: RequestOptionsArgs): Observable<Response>;
+  getList(options?: RequestOptionsArgs): Observable<Object>;
+  get(customId: number, options?: RequestOptionsArgs): Observable<Object>;
+  create(body: any, options?: RequestOptionsArgs): Observable<Object>;
+  update(customId: number, body: any, options?: RequestOptionsArgs): Observable<Object>;
+  delete(customId: number, options?: RequestOptionsArgs): Observable<Object>;
 }

--- a/src/wp-api-angular.ts
+++ b/src/wp-api-angular.ts
@@ -1,46 +1,41 @@
-import {
-  Provider,
-  NgModule,
-  ModuleWithProviders
-} from '@angular/core';
-import 'rxjs';
-import { Http, HttpModule } from '@angular/http';
+import { HttpClient, HttpClientModule } from "@angular/common/http";
+import { ModuleWithProviders, NgModule } from "@angular/core";
+import "rxjs";
+import { WpApiComments } from "./Comments";
+import { WpApiCustom } from "./Custom";
+import { WpApiLoader, WpApiStaticLoader } from "./Loaders";
+import { WpApiMedia } from "./Media";
+import { WpApiPages } from "./Pages";
+import { WpApiPosts } from "./Posts";
+import { WpApiStatuses } from "./Statuses";
+import { WpApiTaxonomies } from "./Taxonomies";
+import { WpApiTerms } from "./Terms";
+import { WpApiTypes } from "./Types";
+import { WpApiUsers } from "./Users";
 
-import { WpApiPosts } from './Posts';
-import { WpApiPages } from './Pages';
-import { WpApiComments } from './Comments';
-import { WpApiTypes } from './Types';
-import { WpApiMedia } from './Media';
-import { WpApiUsers } from './Users';
-import { WpApiTaxonomies } from './Taxonomies';
-import { WpApiStatuses } from './Statuses';
-import { WpApiTerms } from './Terms';
-import { WpApiCustom } from './Custom';
-import { WpApiLoader, WpApiStaticLoader } from './Loaders';
 
-export { WpApiPosts } from './Posts';
-export { WpApiPages } from './Pages';
-export { WpApiComments } from './Comments';
-export { WpApiTypes } from './Types';
-export { WpApiMedia } from './Media';
-export { WpApiUsers } from './Users';
-export { WpApiTaxonomies } from './Taxonomies';
-export { WpApiStatuses } from './Statuses';
-export { WpApiTerms } from './Terms';
-export { WpApiCustom } from './Custom';
-export { WpApiLoader, WpApiStaticLoader } from './Loaders';
+export { WpApiComments } from "./Comments";
+export { WpApiCustom } from "./Custom";
+export { WpApiLoader, WpApiStaticLoader } from "./Loaders";
+export { WpApiMedia } from "./Media";
+export { WpApiPages } from "./Pages";
+export { WpApiPosts } from "./Posts";
+export { WpApiStatuses } from "./Statuses";
+export { WpApiTaxonomies } from "./Taxonomies";
+export { WpApiTerms } from "./Terms";
+export { WpApiTypes } from "./Types";
+export { WpApiUsers } from "./Users";
 
-export function WpApiLoaderFactory(http: Http) {
+export function WpApiLoaderFactory(http: HttpClient) {
   return new WpApiStaticLoader(http);
 }
 
+/******************************************************************************
+* Module: WpApiModule
+******************************************************************************/
 @NgModule({
-  imports: [
-    HttpModule
-  ],
-  exports: [
-    HttpModule
-  ],
+  imports: [HttpClientModule],
+  exports: [HttpClientModule],
   providers: [
     WpApiPosts,
     WpApiPages,
@@ -51,20 +46,23 @@ export function WpApiLoaderFactory(http: Http) {
     WpApiTaxonomies,
     WpApiStatuses,
     WpApiTerms,
-    WpApiCustom
-  ]
+    WpApiCustom,
+  ],
 })
 export class WpApiModule {
-  static forRoot(providedLoader: any = {
-    provide: WpApiLoader,
-    useFactory: WpApiLoaderFactory,
-    deps: [Http]
-  }): ModuleWithProviders {
+
+  public static forRoot(
+    providedLoader: any = {
+      provide: WpApiLoader,
+      useFactory: WpApiLoaderFactory,
+      deps: [HttpClient],
+    }
+  ): ModuleWithProviders<WpApiModule> {
+
     return {
       ngModule: WpApiModule,
-      providers: [
-        providedLoader
-      ]
+      providers: [providedLoader],
     };
+
   }
 }


### PR DESCRIPTION
I bumped dependencies to Angular v11
I also could not figure out why there were duplicate interfaces defined everywhere (like IWpApiComments for instance), so I consolidated them;